### PR TITLE
[Codex] hero: YASURAGIリンクを非表示化（hidden/aria-hidden/tabindex）

### DIFF
--- a/index.html
+++ b/index.html
@@ -104,11 +104,13 @@
                 <h1 class="artist-name">appriver</h1>
                 <p class="description">created with SUNO AI</p>
                 
-                <!-- YASURAGI Release Info -->
+                <!-- YASURAGI Release Info: 一時的に非表示（将来再利用のためDOM保持） -->
                 <a href="/out/yasuragi" 
                    target="_blank" 
                    class="hero-release-button new-release"
-                   aria-label="YASURAGIアルバムを聴く">
+                   aria-label="YASURAGIアルバムを聴く"
+                   rel="nofollow noopener"
+                   hidden aria-hidden="true" tabindex="-1">
                     2025.8.22<br>
                     2ndアルバム「YASURAGI」<br>
                     全ストアにて配信開始<br>


### PR DESCRIPTION
- ヒーローのYASURAGIリンクを非表示化（hidden/aria-hidden/tabindex=-1）\n- hrefは /out/yasuragi を維持（将来再有効化も即時可能）\n- npm run verify 合格済み