### PR TITLE
[Codex] album: YASURAGI告知のアニメーション停止＋『配信中』へ統一

### DIFF
--- a/index.html
+++ b/index.html
@@ -330,7 +330,7 @@
                         <div class="album-details">
                             <h3>YASURAGI</h3>
                             <p class="track-count">15曲</p>
-                            <p class="release-date new-release">2025.8.22<br>全ストアにて配信開始</p>
+                            <p class="release-date">2025.8.22<br>全ストアにて配信中</p>
                             <a href="/out/yasuragi" class="stream-link" target="_blank">聴いてみる</a>
                         </div>
                     </div>


### PR DESCRIPTION
- albumセクションのYASURAGIの告知表示をNUKUMORIと同等に変更\n  -  → （アニメーション停止）\n  - 文言: 『2025.8.22 全ストアにて配信中』に統一\n- 
> appriver-official-site@1.0.0 verify
> npm run format:check && npm run lint


> appriver-official-site@1.0.0 format:check
> prettier --check .

Checking formatting...
All matched files use Prettier code style!

> appriver-official-site@1.0.0 lint
> eslint *.js 合格（format:check / lint）