### PR TITLE
[Codex] hero: カラオケクーポンのリンク先を kr/83855 に更新

### DIFF
--- a/out/karaoke-coupon/index.html
+++ b/out/karaoke-coupon/index.html
@@ -9,7 +9,7 @@
       window.va = window.va || function () {
         (window.vaq = window.vaq || []).push(arguments);
       };
-      window.REDIRECT_TO = 'https://social.kicks.video/v1/re/kr/82108/joysound_coupon?utm_source=vk&utm_medium=sw&utm_campaign=share&utm_term=82108';
+      window.REDIRECT_TO = 'https://social.kicks.video/v1/re/kr/83855/joysound_coupon';
     </script>
     <script defer src="/_vercel/insights/script.js"></script>
   </head>
@@ -19,4 +19,3 @@
     </script>
   </body>
   </html>
-

--- a/vercel.json
+++ b/vercel.json
@@ -66,7 +66,7 @@
     },
     {
       "source": "/out/karaoke-coupon",
-      "destination": "/out/index.html?to=https%3A%2F%2Fsocial.kicks.video%2Fv1%2Fre%2Fkr%2F82108%2Fjoysound_coupon%3Futm_source%3Dvk%26utm_medium%3Dsw%26utm_campaign%3Dshare%26utm_term%3D82108&platform=coupon"
+      "destination": "/out/index.html?to=https%3A%2F%2Fsocial.kicks.video%2Fv1%2Fre%2Fkr%2F83855%2Fjoysound_coupon&platform=coupon"
     }
   ]
 }


### PR DESCRIPTION
- ヒーローのカラオケクーポンリンクの遷移先を更新\n  - out/karaoke-coupon/index.html の REDIRECT_TO を 83855 に変更\n  - vercel.json の rewrites も 83855 に更新\n- /out 経由のため、HobbyでもPVでクリック概数を集計可能\n- 
> appriver-official-site@1.0.0 verify
> npm run format:check && npm run lint


> appriver-official-site@1.0.0 format:check
> prettier --check .

Checking formatting...
All matched files use Prettier code style!

> appriver-official-site@1.0.0 lint
> eslint *.js 合格（format:check / lint）