### PR TITLE
[Codex] players: Amazon/LINEを追加 + モバイル3x2グリッド最適化

### DIFF
--- a/analytics.js
+++ b/analytics.js
@@ -49,6 +49,11 @@
       track('playlist_outbound_click', { platform: 'others' });
       return;
     }
+    const lineBtn = target.closest('.line-full-playlist-btn');
+    if (lineBtn) {
+      track('playlist_outbound_click', { platform: 'line-music' });
+      return;
+    }
 
     // 3) フッター等のソーシャル/配信リンク
     const social = target.closest('.social-link');

--- a/index.html
+++ b/index.html
@@ -211,10 +211,20 @@
                         </div>
                     </div>
                     <div class="player-embed" id="line-music-player" style="display: none;">
-                        <div class="line-direct-container coming-soon-message">
-                            <i class="fab fa-line"></i>
-                            <h3>LINE Music</h3>
-                            <p>リンク準備中です。</p>
+                        <div class="line-direct-container">
+                            <div class="line-header">
+                                <div class="line-logo">
+                                    <i class="fab fa-line"></i>
+                                    <span>LINE Music</span>
+                                </div>
+                            </div>
+                            
+                            <div class="line-playlist-link">
+                                <a href="/out/line-music" target="_blank" class="line-full-playlist-btn">
+                                    <i class="fas fa-external-link-alt"></i>
+                                    <span>プレイリストを開く</span>
+                                </a>
+                            </div>
                         </div>
                     </div>
                     <div class="player-embed" id="youtube-player" style="display: none;">

--- a/index.html
+++ b/index.html
@@ -150,10 +150,6 @@
                         <i class="fab fa-spotify"></i>
                         Spotify
                     </button>
-                    <button class="platform-btn" data-platform="amazon">
-                        <i class="fab fa-amazon"></i>
-                        Amazon
-                    </button>
                     <button class="platform-btn" data-platform="line-music">
                         <i class="fab fa-line"></i>
                         LINE Music
@@ -161,6 +157,10 @@
                     <button class="platform-btn" data-platform="youtube">
                         <i class="fab fa-youtube"></i>
                         YouTube
+                    </button>
+                    <button class="platform-btn" data-platform="amazon">
+                        <i class="fab fa-amazon"></i>
+                        Amazon
                     </button>
                     <button class="platform-btn" data-platform="others">
                         <i class="fas fa-external-link-alt"></i>

--- a/index.html
+++ b/index.html
@@ -150,6 +150,14 @@
                         <i class="fab fa-spotify"></i>
                         Spotify
                     </button>
+                    <button class="platform-btn" data-platform="amazon">
+                        <i class="fab fa-amazon"></i>
+                        Amazon
+                    </button>
+                    <button class="platform-btn" data-platform="line-music">
+                        <i class="fab fa-line"></i>
+                        LINE Music
+                    </button>
                     <button class="platform-btn" data-platform="youtube">
                         <i class="fab fa-youtube"></i>
                         YouTube
@@ -193,6 +201,20 @@
                                     <span>プレイリストを開く</span>
                                 </a>
                             </div>
+                        </div>
+                    </div>
+                    <div class="player-embed" id="amazon-player" style="display: none;">
+                        <div class="amazon-direct-container coming-soon-message">
+                            <i class="fab fa-amazon"></i>
+                            <h3>Amazon Music</h3>
+                            <p>リンク準備中です。</p>
+                        </div>
+                    </div>
+                    <div class="player-embed" id="line-music-player" style="display: none;">
+                        <div class="line-direct-container coming-soon-message">
+                            <i class="fab fa-line"></i>
+                            <h3>LINE Music</h3>
+                            <p>リンク準備中です。</p>
                         </div>
                     </div>
                     <div class="player-embed" id="youtube-player" style="display: none;">

--- a/music-players.js
+++ b/music-players.js
@@ -63,6 +63,16 @@ function stopAllOtherPlayers(currentPlatform) {
     stopOthersPlayer();
   }
 
+  // Amazon停止
+  if (currentPlatform !== 'amazon') {
+    stopAmazonPlayer();
+  }
+
+  // LINE Music停止
+  if (currentPlatform !== 'line-music') {
+    stopLineMusicPlayer();
+  }
+
   console.log(`Stopped all players except ${currentPlatform}`);
 }
 
@@ -92,6 +102,16 @@ function stopOthersPlayer() {
   // 直接リンク方式では埋め込みプレイヤーがないため、停止処理は不要
   // ただし、一貫性のためにログを出力
   console.log('Others player stopped (direct link mode)');
+}
+
+// Amazon Music 停止（直接リンク表示のため実質不要）
+function stopAmazonPlayer() {
+  console.log('Amazon Music player stopped (placeholder mode)');
+}
+
+// LINE Music 停止（直接リンク表示のため実質不要）
+function stopLineMusicPlayer() {
+  console.log('LINE Music player stopped (placeholder mode)');
 }
 
 // セクション移動検知とプレイヤー停止

--- a/out/line-music/index.html
+++ b/out/line-music/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>リダイレクト中...</title>
+    <meta name="robots" content="noindex, nofollow" />
+    <script>
+      window.va = window.va || function () { (window.vaq = window.vaq || []).push(arguments); };
+      window.REDIRECT_TO = 'https://music.line.me/webapp/playlist/upi7nLrdtfvhxjzl9Eel6t3v5zzqyDypzjJn?myAlbumIf=true';
+    </script>
+    <script defer src="/_vercel/insights/script.js"></script>
+  </head>
+  <body>
+    <script>location.replace(window.REDIRECT_TO);</script>
+  </body>
+  </html>
+

--- a/style.css
+++ b/style.css
@@ -2020,6 +2020,97 @@ section h2::after {
   font-size: 1.2rem;
 }
 
+/* LINE Music Direct Layout Styles */
+.line-direct-container {
+  background: linear-gradient(135deg, #fff9f7 0%, #f5f0ec 50%, #f0e8e1 100%);
+  border-radius: 20px;
+  padding: 3rem 2rem;
+  border: 2px solid rgba(232, 164, 139, 0.3);
+  box-shadow: 0 8px 30px rgba(232, 164, 139, 0.1);
+  min-height: 350px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: space-between;
+  text-align: center;
+  gap: 1.5rem;
+}
+
+.line-header {
+  flex-shrink: 0;
+}
+
+.line-logo {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1.2rem;
+}
+
+.line-logo i {
+  font-size: 4rem;
+  color: #06c755; /* LINE brand color */
+  animation: pulse 2s ease-in-out infinite alternate;
+  filter: drop-shadow(0 4px 8px rgba(6, 199, 85, 0.3));
+}
+
+.line-logo span {
+  font-size: 2.5rem;
+  font-weight: 900;
+  color: #333;
+  letter-spacing: -0.5px;
+}
+
+.line-playlist-link {
+  flex-shrink: 0;
+}
+
+.line-full-playlist-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.8rem;
+  background: linear-gradient(135deg, #e8a48b 0%, #d49175 100%);
+  color: white;
+  padding: 1.5rem 1rem;
+  border-radius: 40px;
+  text-decoration: none;
+  font-weight: 600;
+  font-size: 1.1rem;
+  transition: all 0.3s ease;
+  border: 2px solid #e8a48b;
+  box-shadow: 0 6px 20px rgba(232, 164, 139, 0.3);
+  position: relative;
+  overflow: hidden;
+  width: calc(140px * 4 + 1rem * 3);
+  max-width: 100%;
+  min-height: calc(60px * 2 + 1rem);
+}
+
+.line-full-playlist-btn::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: -100%;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.2), transparent);
+  transition: left 0.6s ease;
+}
+
+.line-full-playlist-btn:hover::before {
+  left: 100%;
+}
+
+.line-full-playlist-btn:hover {
+  background: linear-gradient(135deg, #d49175 0%, #c17d61 100%);
+  transform: translateY(-5px) scale(1.08);
+  box-shadow: 0 15px 40px rgba(232, 164, 139, 0.6);
+}
+
+.line-full-playlist-btn i {
+  font-size: 1.2rem;
+}
 /* Footer */
 footer {
   background: #333;
@@ -2679,6 +2770,59 @@ footer {
     min-height: 60px;
   }
 
+  /* LINE Music Mobile Optimizations - コンパクト */
+  .line-direct-container {
+    padding: 1rem;
+    min-height: auto;
+    gap: 0.8rem;
+    justify-content: center;
+  }
+
+  .line-header {
+    height: 60px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .line-logo i {
+    font-size: 2.2rem;
+  }
+  .line-logo span {
+    font-size: 1.4rem;
+    font-weight: 600;
+  }
+
+  .line-playlist-link {
+    height: 60px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .line-full-playlist-btn {
+    padding: 0.8rem 1rem;
+    font-size: 1.2rem;
+    font-weight: 900;
+    width: calc(75px * 4 + 0.5rem * 3);
+    max-width: 90%;
+    border-radius: 30px;
+    gap: 0.8rem;
+    border-width: 2px;
+    box-shadow: 0 4px 15px rgba(232, 164, 139, 0.2);
+    touch-action: manipulation;
+    -webkit-tap-highlight-color: transparent;
+    height: 60px;
+    min-height: 60px;
+  }
+
+  .line-full-playlist-btn i {
+    font-size: 1.3rem;
+  }
+  .line-full-playlist-btn:active {
+    transform: translateY(-1px) scale(0.98);
+    box-shadow: 0 4px 15px rgba(232, 164, 139, 0.3);
+  }
   .youtube-full-playlist-btn i {
     font-size: 1.3rem;
   }

--- a/style.css
+++ b/style.css
@@ -2363,24 +2363,24 @@ footer {
     font-size: 0.7rem;
   }
 
-  /* Platform Selector Mobile - 2x2 Grid */
+  /* Platform Selector Mobile - 3x2 Grid (6 buttons) */
   .platform-selector {
     display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 0.8rem;
-    max-width: 300px;
-    margin: 0 auto 2rem auto;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 0.6rem;
+    max-width: 360px;
+    margin: 0 auto 1.5rem auto;
   }
 
   .platform-btn {
-    padding: 0.8rem 0.6rem;
+    padding: 0.6rem 0.4rem;
     min-width: auto;
-    font-size: 0.85rem;
+    font-size: 0.8rem;
   }
 
   .platform-btn i {
-    font-size: 1.4rem;
-    margin-bottom: 0.3rem;
+    font-size: 1.2rem;
+    margin-bottom: 0.25rem;
   }
 
   /* Song Slider Extra Small Mobile */

--- a/vercel.json
+++ b/vercel.json
@@ -46,6 +46,10 @@
       "destination": "/out/index.html?to=https%3A%2F%2Fwww.youtube.com%2F%40appriver12&platform=youtube"
     },
     {
+      "source": "/out/line-music",
+      "destination": "/out/index.html?to=https%3A%2F%2Fmusic.line.me%2Fwebapp%2Fplaylist%2Fupi7nLrdtfvhxjzl9Eel6t3v5zzqyDypzjJn%3FmyAlbumIf%3Dtrue&platform=line"
+    },
+    {
       "source": "/out/others",
       "destination": "/out/index.html?to=https%3A%2F%2Fwww.tunecore.co.jp%2Fartists%3Fid%3D991248&platform=others"
     },


### PR DESCRIPTION
- プラットフォームボタンを2→追加（Amazon, LINE）\n- player-embedを追加（リンク準備中のプレースホルダ表示）\n- モバイルのレイアウトを3列x2段のグリッドに変更\n  - ボタンのpadding/フォント/アイコンを縮小\n  - 1画面に収めやすい余白調整\n- 既存の切替・停止処理にAmazon/LINEを追加（placeholder停止）\n- verify合格済み