### PR TITLE
[Codex] out: /out/line-music 遷移の堅牢化（末尾/＋slugフォールバック）

### DIFF
--- a/index.html
+++ b/index.html
@@ -220,7 +220,7 @@
                             </div>
                             
                             <div class="line-playlist-link">
-                                <a href="/out/line-music" target="_blank" class="line-full-playlist-btn">
+                                <a href="/out/line-music/" target="_blank" class="line-full-playlist-btn">
                                     <i class="fas fa-external-link-alt"></i>
                                     <span>プレイリストを開く</span>
                                 </a>

--- a/out/index.html
+++ b/out/index.html
@@ -66,6 +66,28 @@
       (function () {
         var params = new URLSearchParams(location.search);
         var to = window.REDIRECT_TO || params.get('to');
+        // Fallback: rewritesが無効で /out/<slug> に直接来た場合のスラッグ解決
+        if (!to) {
+          try {
+            var m = (location.pathname || '').match(/\/out\/([^\/?#]+)/);
+            var slug = m && m[1];
+            if (slug) {
+              var map = {
+                'line-music': 'https://music.line.me/webapp/playlist/upi7nLrdtfvhxjzl9Eel6t3v5zzqyDypzjJn?myAlbumIf=true',
+                'apple-music': 'https://music.apple.com/jp/playlist/appriver-%E5%85%AC%E5%BC%8F%E3%83%97%E3%83%AC%E3%82%A4%E3%83%AA%E3%82%B9%E3%83%88/pl.u-V9D7vD9FEP64AZ',
+                spotify: 'https://open.spotify.com/playlist/1Y4ICAnET0o7CPHRycOriz',
+                youtube: 'https://www.youtube.com/@appriver12',
+                others: 'https://www.tunecore.co.jp/artists?id=991248',
+                'spotify-artist': 'https://open.spotify.com/intl-ja/artist/2PbgbV4vBCzAUV9ZfHPG3Z',
+                'apple-artist': 'https://music.apple.com/jp/artist/%E3%82%A2%E3%83%83%E3%83%97%E3%83%AA%E3%83%90%E3%83%BC/1816403477',
+                yasuragi: 'https://linkco.re/1gXERgmA',
+                nukumori: 'https://linkco.re/E7hxe2Ay',
+                'karaoke-coupon': 'https://social.kicks.video/v1/re/kr/83855/joysound_coupon?utm_source=vk&utm_medium=sw&utm_campaign=share&utm_term=83855',
+              };
+              if (map[slug]) to = map[slug];
+            }
+          } catch (_) {}
+        }
         try {
           if (to) to = decodeURIComponent(to);
         } catch (_) {}


### PR DESCRIPTION
- LINE Musicのリンクを  に変更（ディレクトリindex解決を確実化）\n- out/index.html に slug→URL フォールバックを追加（rewrites無効時でも遷移）\n- 他の主要slug（apple/spotify/youtube/others等）もフォールバックに含め、将来の再発を防止\n- verify合格済み