### PR TITLE
[Codex] players: 表示ラベル変更＋サイズ再調整（スマホ3x2最適化）

### DIFF
--- a/index.html
+++ b/index.html
@@ -144,7 +144,7 @@
                 <div class="platform-selector">
                     <button class="platform-btn active" data-platform="apple-music">
                         <i class="fab fa-apple"></i>
-                        Apple Music
+                        Apple
                     </button>
                     <button class="platform-btn" data-platform="spotify">
                         <i class="fab fa-spotify"></i>
@@ -152,7 +152,7 @@
                     </button>
                     <button class="platform-btn" data-platform="line-music">
                         <i class="fab fa-line"></i>
-                        LINE Music
+                        LINE
                     </button>
                     <button class="platform-btn" data-platform="youtube">
                         <i class="fab fa-youtube"></i>
@@ -164,7 +164,7 @@
                     </button>
                     <button class="platform-btn" data-platform="others">
                         <i class="fas fa-external-link-alt"></i>
-                        Others
+                        その他
                     </button>
                 </div>
 

--- a/style.css
+++ b/style.css
@@ -2459,19 +2459,20 @@ footer {
     display: grid;
     grid-template-columns: repeat(3, 1fr);
     gap: 0.6rem;
-    max-width: 360px;
-    margin: 0 auto 1.5rem auto;
+    max-width: 340px;
+    margin: 0 auto 1.2rem auto;
   }
 
   .platform-btn {
-    padding: 0.6rem 0.4rem;
+    padding: 0.55rem 0.35rem;
     min-width: auto;
-    font-size: 0.8rem;
+    font-size: 0.78rem;
+    white-space: nowrap;
   }
 
   .platform-btn i {
-    font-size: 1.2rem;
-    margin-bottom: 0.25rem;
+    font-size: 1.15rem;
+    margin-bottom: 0.2rem;
   }
 
   /* Song Slider Extra Small Mobile */


### PR DESCRIPTION
- ボタン表示: Apple / Spotify / LINE / YouTube / Amazon / その他\n- モバイル3x2グリッドで1画面に収まるようサイズ微調整（max-width, padding, font, icon, nowrap）\n- verify 合格済み。マージ後に本番へ昇格します。