### PR TITLE
[Codex] apple: プレイリスト→選択画面（ブラウザ/アプリ）へ変更

### DIFF
--- a/index.html
+++ b/index.html
@@ -179,15 +179,9 @@
                             </div>
                             
                             <div class="apple-music-playlist-link">
-                                <a href="/out/apple-music-embed/" class="apple-music-embed-btn">
+                                <a href="/out/apple-music-select/" class="apple-music-full-playlist-btn">
                                     <i class="fas fa-external-link-alt"></i>
-                                    <span>ブラウザで開く（埋め込み）</span>
-                                </a>
-                            </div>
-                            <div class="apple-music-playlist-link">
-                                <a href="/out/apple-music/" class="apple-music-full-playlist-btn">
-                                    <i class="fas fa-external-link-alt"></i>
-                                    <span>アプリで開く</span>
+                                    <span>プレイリストを開く</span>
                                 </a>
                             </div>
                         </div>

--- a/out/apple-music-select/index.html
+++ b/out/apple-music-select/index.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Apple Music を開く</title>
+    <meta name="robots" content="noindex, nofollow" />
+    <script>
+      window.va = window.va || function () {
+        (window.vaq = window.vaq || []).push(arguments);
+      };
+    </script>
+    <script defer src="/_vercel/insights/script.js"></script>
+    <style>
+      :root { color-scheme: light; }
+      body { font-family: system-ui, -apple-system, "Noto Sans JP", Roboto, Arial, sans-serif; margin: 0; padding: 2rem; color: #333; }
+      .wrap { max-width: 560px; margin: 6vh auto 0; border: 1px solid #eee; border-radius: 14px; padding: 1.2rem; box-shadow: 0 6px 24px rgba(0,0,0,.06); background: #fff; }
+      h1 { font-size: 1.2rem; margin: 0 0 0.6rem; }
+      p { margin: 0.4rem 0 1rem; color: #555; font-size: .95rem; }
+      .btns { display: grid; grid-template-columns: 1fr; gap: .6rem; margin-top: .8rem; }
+      .btn { display: inline-flex; align-items: center; justify-content: center; gap: .6rem; background: linear-gradient(135deg,#e8a48b,#d49175); color:#fff; text-decoration:none; border-radius: 32px; padding: .9rem 1rem; border:2px solid #e8a48b; box-shadow: 0 6px 20px rgba(232,164,139,.25); font-weight: 600; }
+      .btn.secondary { background: #fff; color:#e08f71; border-color:#e08f71; }
+      .btn:active { transform: translateY(0); box-shadow: 0 4px 12px rgba(232,164,139,.25); }
+      .hint { font-size: .85rem; color:#777; margin-top: .6rem; }
+      @media (min-width: 480px) { .btns { grid-template-columns: 1fr 1fr; } }
+    </style>
+  </head>
+  <body>
+    <div class="wrap">
+      <h1>Apple Music を開く</h1>
+      <p>開き方を選択してください。</p>
+      <div class="btns">
+        <a class="btn" href="/out/apple-music-embed/">ブラウザで開く（埋め込み）</a>
+        <a class="btn secondary" href="/out/apple-music/">アプリで開く</a>
+      </div>
+      <p class="hint">戻る操作がしやすいのは「ブラウザで開く（埋め込み）」です。</p>
+    </div>
+  </body>
+  </html>
+


### PR DESCRIPTION
- Appleの『プレイリストを開く』を選択画面に変更\n- /out/apple-music-select/ を新設（ブラウザ：/out/apple-music-embed／アプリ：/out/apple-music）\n- 404回避と戻る操作の安定化を優先（embedはSafari内で表示）\n- verify合格済み。マージ後に本番昇格します。