### PR TITLE
[Claude] fix: change IROZUKI button link to music players

### DIFF
--- a/index.html
+++ b/index.html
@@ -112,8 +112,8 @@
                 <h1 class="artist-name">appriver</h1>
                 <p class="description">created with SUNO AI</p>
 
-                <!-- IROZUKI Release CTA: アルバムセクションへ遷移 -->
-                <a href="#album" class="hero-release-button new-release" aria-label="IROZUKIアルバムを聴く">
+                <!-- IROZUKI Release CTA: ミュージックプレイヤーへ遷移 -->
+                <a href="#music-players" class="hero-release-button new-release" aria-label="IROZUKIを今すぐ聴く">
                     2026.1.30<br>
                     NEW ALBUM 「IROZUKI」<br>
                     全ストアにて配信開始<br>


### PR DESCRIPTION
ヒーローセクションのIROZUKI「今すぐ聴く」ボタンの遷移先を変更します。

## 変更内容
- `#album` → `#music-players` に変更
- aria-labelも更新

これにより、ユーザーが「今すぐ聴く」をタップするとMusic Playersセクションに遷移し、すぐに各プラットフォームで再生できます。